### PR TITLE
ci: automate npm publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,8 @@ jobs:
     - name: Release prebuilt artifacts (win ia32)
       if: github.event_name == 'release' && github.event.action == 'published' && startsWith(matrix.os, 'windows')
       run: npx prebuild --all -r napi --arch ia32 -u ${{ secrets.GITHUB_TOKEN }}
+    - name: Release to npm
+      if: github.event_name == 'release' && github.event.action == 'published' && startsWith(matrix.os, 'macos')
+      run: npm publish --access public
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Requires npm access token in GH secret NPM_TOKEN
