### PR TITLE
ci: prebuildify for linux-arm64 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
           - os: ubuntu-20.04
             arch: x64
             build-group: linux-x64
+          - os: ubuntu-20.04
+            arch: x64
+            build-group: linux-arm64
           - os: macos-11
             arch: x64
             build-group: darwin-universal
@@ -38,17 +41,32 @@ jobs:
       with:
         node-version: '16'
         architecture: ${{ matrix.arch }}
-    - name: Install linux dependencies
-      if: startsWith(matrix.os, 'ubuntu')
+    - name: Prebuildify for linux-arm64
+      if: ${{ matrix.build-group == 'linux-arm64' }}
+      uses: pguyot/arm-runner-action@v2
+      with:
+        base_image: raspios_lite_arm64:latest
+        image_additional_mb: 5000
+        copy_artifact_path: prebuilds
+        commands: |
+            curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
+            apt-get -y install nodejs libxtst-dev libpng++-dev
+            npm ci
+            npm run prebuild-$BUILD_GROUP
+    - name: Install linux x64 dependencies
+      if: ${{ matrix.build-group == 'linux-x64' }}
       run: sudo apt-get install libxtst-dev libpng++-dev
     - run: npm ci
+      if: ${{ matrix.build-group != 'linux-arm64' }}
     - name: Prebuildify
+      if: ${{ matrix.build-group != 'linux-arm64' }}
       run: npm run prebuild-$BUILD_GROUP
       shell: bash
     - uses: actions/upload-artifact@v3
       with:
         name: prebuilds
         path: prebuilds/
+        if-no-files-found: error
   publish:
     name: Publish to npm
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,19 +33,19 @@ jobs:
     env:
       BUILD_GROUP: ${{ matrix.build-group }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
       with:
         node-version: '16'
         architecture: ${{ matrix.arch }}
     - name: Install linux dependencies
       if: startsWith(matrix.os, 'ubuntu')
       run: sudo apt-get install libxtst-dev libpng++-dev
-    - run: npm install
+    - run: npm ci
     - name: Prebuildify
       run: npm run prebuild-$BUILD_GROUP
       shell: bash
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: prebuilds
         path: prebuilds/
@@ -55,17 +55,18 @@ jobs:
     runs-on: ubuntu-20.04
     needs: build
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/download-artifact@v2
+    - uses: actions/checkout@v3
+    - uses: actions/download-artifact@v3
       with:
         name: prebuilds
         path: prebuilds
-    - uses: phips28/gh-action-bump-version@608cab1205a5560a93eb66b4a64e4acf2119597b
+    - uses: phips28/gh-action-bump-version@95099cd5edcdae43499bc94202b9d907e739e9c8
       with:
         tag-prefix: 'v'
+        version-type: 'patch'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v3
       with:
         node-version: '16'
         registry-url: 'https://registry.npmjs.org'

--- a/package-lock.json
+++ b/package-lock.json
@@ -700,14 +700,14 @@
       "dev": true
     },
     "node_modules/get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
+      "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
       "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
+        "has-symbols": "^1.0.3"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -818,9 +818,9 @@
       }
     },
     "node_modules/has-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
       "dev": true,
       "engines": {
         "node": ">= 0.4"
@@ -1355,10 +1355,13 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/mkdirp": {
       "version": "0.5.5",
@@ -3054,14 +3057,14 @@
       "dev": true
     },
     "get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
+      "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
+        "has-symbols": "^1.0.3"
       }
     },
     "get-stdin": {
@@ -3141,9 +3144,9 @@
       "dev": true
     },
     "has-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
       "dev": true
     },
     "has-tostringtag": {
@@ -3539,9 +3542,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true
     },
     "mkdirp": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "prebuild": "prebuildify -t 16.0.0 --napi --strip",
     "prebuild-darwin-universal": "prebuildify -t 16.0.0 --napi --strip --arch x64+arm64",
     "prebuild-linux-x64": "prebuildify -t 16.0.0 --napi --strip",
+    "prebuild-linux-arm64": "prebuildify -t 16.0.0 --napi --strip",
     "prebuild-win32-x86": "prebuildify -t 16.0.0 --napi --strip",
     "prebuild-win32-x64": "prebuildify -t 16.0.0 --napi --strip"
   },


### PR DESCRIPTION
Uses https://github.com/pguyot/arm-runner-action to have a native
arm64 linux environment to compile the prebuild for linux-arm64.

prebuildify-cross would be easier, but unfortunately does not work
due to the xtst headers not present in the docker images that
prebuildify-cross uses internally.